### PR TITLE
fix(security): path traversal in install_pack via zip metadata

### DIFF
--- a/services/packs/pack_registry.py
+++ b/services/packs/pack_registry.py
@@ -1,9 +1,28 @@
 import os
+import re
 import shutil
 from typing import Dict, List, Optional
 
+from ..safe_io import resolve_under_root
 from .pack_archive import PackArchive, PackError
 from .pack_types import PackMetadata
+
+# Strict pattern for pack name and version path segments.
+# Only allows alphanumerics, hyphens, underscores, and dots.
+_SAFE_SEGMENT_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+
+def _validate_pack_segment(value: str, label: str) -> None:
+    """Validate a pack name or version segment against path traversal."""
+    if not value:
+        raise PackError(f"Pack {label} must not be empty")
+    if not _SAFE_SEGMENT_RE.match(value):
+        raise PackError(
+            f"Pack {label} contains invalid characters: {value!r}. "
+            f"Only alphanumerics, hyphens, underscores, and dots are allowed."
+        )
+    if value in (".", ".."):
+        raise PackError(f"Pack {label} must not be '.' or '..'")
 
 
 class PackRegistry:
@@ -33,7 +52,13 @@ class PackRegistry:
             name = meta["name"]
             version = meta["version"]
 
-            target_dir = os.path.join(self.packs_dir, name, version)
+            # Validate name/version from zip metadata against path traversal.
+            # A malicious pack.json could contain traversal sequences.
+            _validate_pack_segment(name, "name")
+            _validate_pack_segment(version, "version")
+            target_dir = resolve_under_root(
+                self.packs_dir, os.path.join(name, version)
+            )
 
             if os.path.exists(target_dir):
                 if not overwrite:

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -6,6 +6,7 @@ import unittest
 import zipfile
 
 from services.packs.pack_archive import PackArchive
+from services.packs.pack_registry import PackRegistry
 from services.packs.pack_manifest import (
     MAX_MANIFEST_FILES,
     PackError,
@@ -100,6 +101,59 @@ class TestPackSecurity(unittest.TestCase):
 
         with self.assertRaisesRegex(PackError, "Too many files"):
             PackArchive.extract_pack(zip_path, os.path.join(self.test_dir, "out"))
+
+
+class TestPackRegistryInstallTraversal(unittest.TestCase):
+    """Test that install_pack rejects traversal sequences in zip metadata."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.registry = PackRegistry(self.test_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def _make_pack_zip(self, name, version):
+        """Create a minimal valid pack zip with the given name/version in metadata."""
+        import hashlib
+
+        zip_path = os.path.join(self.test_dir, "test.zip")
+        pack_meta = {
+            "name": name,
+            "version": version,
+            "type": "preset",
+            "author": "tester",
+            "min_moltbot_version": "0.1.0",
+        }
+        pack_json = json.dumps(pack_meta).encode("utf-8")
+        pack_hash = hashlib.sha256(pack_json).hexdigest()
+        manifest = {"files": [{"path": "pack.json", "sha256": pack_hash}]}
+
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("pack.json", pack_json)
+            zf.writestr("manifest.json", json.dumps(manifest))
+        return zip_path
+
+    def test_install_rejects_traversal_in_name(self):
+        zip_path = self._make_pack_zip("../../etc", "1.0.0")
+        with self.assertRaises(PackError):
+            self.registry.install_pack(zip_path)
+
+    def test_install_rejects_traversal_in_version(self):
+        zip_path = self._make_pack_zip("legit-pack", "../../../tmp")
+        with self.assertRaises(PackError):
+            self.registry.install_pack(zip_path)
+
+    def test_install_rejects_dotdot_name(self):
+        zip_path = self._make_pack_zip("..", "1.0.0")
+        with self.assertRaises(PackError):
+            self.registry.install_pack(zip_path)
+
+    def test_install_accepts_valid_metadata(self):
+        zip_path = self._make_pack_zip("my-pack", "1.0.0")
+        meta = self.registry.install_pack(zip_path)
+        self.assertEqual(meta["name"], "my-pack")
+        self.assertEqual(meta["version"], "1.0.0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Vulnerability:** `PackRegistry.install_pack()` read `name` and `version` from `pack.json` inside uploaded zip archives and used them unsanitized to construct the installation directory path. A malicious zip could contain `"name": "../../arbitrary/path"` in its metadata, causing files to be written outside the intended `packs_dir`.
- **Fix:** Added `_validate_pack_segment()` which rejects empty values, `.`/`..`, and characters outside `[a-zA-Z0-9._-]`. Added `resolve_under_root()` from `safe_io` as a defense-in-depth check to ensure resolved paths stay within `packs_dir`.
- **Tests:** Added `TestPackRegistryInstallTraversal` class with 4 regression tests including a positive test confirming valid packs still install correctly.

## Files Changed

- `services/packs/pack_registry.py` — Added imports, `_validate_pack_segment()` helper, and validation of metadata-sourced name/version in `install_pack()`
- `tests/test_packs.py` — Added `TestPackRegistryInstallTraversal` test class

## Test plan

- [x] All existing `TestPackSecurity` tests continue to pass
- [x] New `TestPackRegistryInstallTraversal` tests pass (4/4)
- [ ] Manual verification: confirm a zip with `"name": "../../etc"` in pack.json raises `PackError`

## Disclosure

This vulnerability was identified during an AI-assisted security audit using Claude Code. The patch was also authored with AI assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)